### PR TITLE
Move away from deprecated SDK methods and cleanup imports

### DIFF
--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -21,7 +21,6 @@ import java.io.Reader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
+++ b/src/main/java/io/prometheus/cloudwatch/DynamicReloadServlet.java
@@ -5,11 +5,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class DynamicReloadServlet extends HttpServlet {
-    private static final Logger LOGGER = Logger.getLogger(CloudWatchCollector.class.getName());
     private static CloudWatchCollector collector;
 
     public DynamicReloadServlet(CloudWatchCollector collector) {

--- a/src/main/java/io/prometheus/cloudwatch/WebServer.java
+++ b/src/main/java/io/prometheus/cloudwatch/WebServer.java
@@ -2,14 +2,9 @@ package io.prometheus.cloudwatch;
 
 import io.prometheus.client.exporter.MetricsServlet;
 import java.io.FileReader;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import sun.misc.Signal;
-import sun.misc.SignalHandler;
 
 public class WebServer {
 

--- a/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
+++ b/src/test/java/io/prometheus/cloudwatch/CloudWatchCollectorTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Matchers.argThat;
 
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.model.Datapoint;
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.DimensionFilter;
@@ -35,12 +35,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class CloudWatchCollectorTest {
-  AmazonCloudWatchClient client;
+  AmazonCloudWatch client;
   CollectorRegistry registry;
 
   @Before
   public void setUp() {
-    client = Mockito.mock(AmazonCloudWatchClient.class);
+    client = Mockito.mock(AmazonCloudWatch.class);
     registry = new CollectorRegistry();
   }
   


### PR DESCRIPTION
- Move away from deprecated sdk methods. Doing so, use the now standard builder pattern. In the case of AmazonCloudWatch, it now works with interface instead of direct implementation.
- Remove unused imports