### PR TITLE
Users should be able to opt in for aws_resource_info explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ metrics:
    aws_statistics: [Sum]
 ```
 
-A similar example with common options and `aws_tag_select`:
+A similar example with common options, `aws_tag_select` and `enable_aws_resource_info`:
 ```
 ---
 region: eu-west-1
+enable_aws_resource_info : true
 metrics:
  - aws_namespace: AWS/ELB
    aws_metric_name: RequestCount
@@ -68,9 +69,10 @@ aws_dimensions | Optional. Which dimension to fan out over.
 aws_dimension_select | Optional. Which dimension values to filter. Specify a map from the dimension name to a list of values to select from that dimension.
 aws_dimension_select_regex | Optional. Which dimension values to filter on with a regular expression. Specify a map from the dimension name to a list of regexes that will be applied to select from that dimension.
 aws_tag_select | Optional. A tag configuration to filter on, based on mapping from the tagged resource ID to a CloudWatch dimension.  
-tag_selections | Required under `aws_tag_select`. Specify a map from a tag key to a list of tag values to apply [tag filtering](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html#resourcegrouptagging-GetResources-request-TagFilters) on resources from which metrics will be gathered.
-resource_type_selection | Required under `aws_tag_select`. Specify the [resource type](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namesspaces) to filter on.
-resource_id_dimension | Required under `aws_tag_select`. For the current metric, specify which CloudWatch dimension maps to the ARN [resource ID](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax).
+tag_selections | Required, under `aws_tag_select`. Specify a map from a tag key to a list of tag values to apply [tag filtering](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html#resourcegrouptagging-GetResources-request-TagFilters) on resources from which metrics will be gathered.
+resource_type_selection | Required, under `aws_tag_select`. Specify the [resource type](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namesspaces) to filter on.
+resource_id_dimension | Required, under `aws_tag_select`. For the current metric, specify which CloudWatch dimension maps to the ARN [resource ID](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax).
+enable_aws_resource_info | Optional, under `aws_tag_select`. Boolean for whether to enable the export of `aws_resource_info` metric from tagging API results. Defaults to false. Can be set globally and per `aws_tag_select`.
 aws_statistics | Optional. A list of statistics to retrieve, values can include Sum, SampleCount, Minimum, Maximum, Average. Defaults to all statistics unless extended statistics are requested.
 aws_extended_statistics | Optional. A list of extended statistics to retrieve. Extended statistics currently include percentiles in the form `pN` or `pN.N`.
 delay_seconds | Optional. The newest data to request. Used to avoid collecting data that has not fully converged. Defaults to 600s. Can be set globally and per metric.
@@ -86,7 +88,7 @@ aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="mylb",av
 aws_elb_request_count_sum{job="aws_elb",instance="",load_balancer_name="myotherlb",availability_zone="eu-west-1c",} 7.0
 ```
 
-If the `aws_tag_select` feature was used, an additional information metric will be exported for each AWS resource matched by the tag selection, such as
+If `enable_aws_resource_info` is set to true, an additional information metric will be exported for each AWS resource matched by `aws_tag_select`, such as
 ```
 # HELP aws_resource_info AWS information available for resource
 # TYPE aws_resource_info gauge

--- a/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
+++ b/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java
@@ -79,6 +79,7 @@ public class CloudWatchCollector extends Collector {
       String resourceTypeSelection;
       String resourceIdDimension;
       Map<String,List<String>> tagSelections;
+      boolean enableAwsResourceInfo;
     }
     
     ActiveConfig activeConfig = new ActiveConfig();
@@ -149,6 +150,11 @@ public class CloudWatchCollector extends Collector {
             defaultCloudwatchTimestamp = (Boolean)config.get("set_timestamp");
         }
 
+        boolean defaultEnableAwsResourceInfo = false;
+        if (config.containsKey("enable_aws_resource_info")) {
+          defaultEnableAwsResourceInfo = (Boolean)config.get("enable_aws_resource_info");
+        }
+        
         if (cloudWatchClient == null) {
           AmazonCloudWatchClientBuilder clientBuilder = AmazonCloudWatchClientBuilder.standard();
 
@@ -242,6 +248,12 @@ public class CloudWatchCollector extends Collector {
             awsTagSelect.resourceTypeSelection = (String)yamlAwsTagSelect.get("resource_type_selection");
             awsTagSelect.resourceIdDimension = (String)yamlAwsTagSelect.get("resource_id_dimension");
             awsTagSelect.tagSelections = (Map<String, List<String>>)yamlAwsTagSelect.get("tag_selections");
+            
+            if (yamlAwsTagSelect.containsKey("enable_aws_resource_info")) {
+              awsTagSelect.enableAwsResourceInfo = (Boolean)yamlAwsTagSelect.get("enable_aws_resource_info");
+            } else {
+              awsTagSelect.enableAwsResourceInfo = defaultEnableAwsResourceInfo;
+            }
           }
         }
 
@@ -621,30 +633,32 @@ public class CloudWatchCollector extends Collector {
           mfs.add(new MetricFamilySamples(baseName + "_" + safeName(toSnakeCase(entry.getKey())), Type.GAUGE, help(rule, unit, entry.getKey()), entry.getValue()));
         }
         
-        // Add the "aws_resource_info" metric for existing tag mappings
-        for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
-          if (!publishedResourceInfo.contains(resourceTagMapping.getResourceARN())) {
-            List<String> labelNames = new ArrayList<String>();
-            List<String> labelValues = new ArrayList<String>();
-            labelNames.add("job");
-            labelValues.add(jobName);
-            labelNames.add("instance");
-            labelValues.add("");
-            labelNames.add("arn");
-            labelValues.add(resourceTagMapping.getResourceARN());
-            labelNames.add(safeName(toSnakeCase(rule.awsTagSelect.resourceIdDimension)));
-            labelValues.add(extractResourceIdFromArn(resourceTagMapping.getResourceARN()));
-            for (Tag tag: resourceTagMapping.getTags()) {
-              // Avoid potential collision between resource tags and other metric labels by adding the "tag_" prefix
-              // The AWS tags are case sensitive, so to avoid loosing information and label collisions, tag keys are not snaked cased
-              labelNames.add("tag_" + safeName(tag.getKey()));
-              labelValues.add(tag.getValue());
+        if (rule.awsTagSelect != null && rule.awsTagSelect.enableAwsResourceInfo) {
+          // Add the "aws_resource_info" metric for existing tag mappings
+          for (ResourceTagMapping resourceTagMapping : resourceTagMappings) {
+            if (!publishedResourceInfo.contains(resourceTagMapping.getResourceARN())) {
+              List<String> labelNames = new ArrayList<String>();
+              List<String> labelValues = new ArrayList<String>();
+              labelNames.add("job");
+              labelValues.add(jobName);
+              labelNames.add("instance");
+              labelValues.add("");
+              labelNames.add("arn");
+              labelValues.add(resourceTagMapping.getResourceARN());
+              labelNames.add(safeName(toSnakeCase(rule.awsTagSelect.resourceIdDimension)));
+              labelValues.add(extractResourceIdFromArn(resourceTagMapping.getResourceARN()));
+              for (Tag tag: resourceTagMapping.getTags()) {
+                // Avoid potential collision between resource tags and other metric labels by adding the "tag_" prefix
+                // The AWS tags are case sensitive, so to avoid loosing information and label collisions, tag keys are not snaked cased
+                labelNames.add("tag_" + safeName(tag.getKey()));
+                labelValues.add(tag.getValue());
+              }
+              List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
+              samples.add(new MetricFamilySamples.Sample("aws_resource_info", labelNames, labelValues, 1));
+              mfs.add(new MetricFamilySamples("aws_resource_info", Type.GAUGE, "AWS information available for resource", samples));
+              
+              publishedResourceInfo.add(resourceTagMapping.getResourceARN());
             }
-            List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
-            samples.add(new MetricFamilySamples.Sample("aws_resource_info", labelNames, labelValues, 1));
-            mfs.add(new MetricFamilySamples("aws_resource_info", Type.GAUGE, "AWS information available for resource", samples));
-            
-            publishedResourceInfo.add(resourceTagMapping.getResourceARN());
           }
         }
       }


### PR DESCRIPTION
Based on upstream PR comments.
The new boolean option can be set either globally, or by metric.